### PR TITLE
Fix: fix Dockerfile to load sample_configs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ COPY --from=builder /app/.yarnrc.yml ./
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/sample_configs ./sample_configs
 
 RUN corepack enable && \
     corepack prepare yarn@3.5.1 --activate && \


### PR DESCRIPTION
📝 Summary

### When:
While running the AutoRAG GUI by cloning the repository with submodules,
I attempted to run the tutorial_1 project's Optimization. However, it failed at the 5th stage (Run Optimization) due to missing configuration files in the /app/sample_configs/ directory. (See image 1)
Upon investigation, I found that the sample_configs folder was not properly mounted inside the Docker container. (See image 2)

### What:
I have updated the AutoRAG/autorag-frontend/Dockerfile to ensure that the sample_configs folder is included in the container under /app/sample_configs. (See image 3)

add line 53: COPY --from=builder /app/sample_configs ./sample_configs

### Why:
This change is necessary to ensure the project runs correctly.
Without this fix, the optimization process cannot proceed as expected.

🛠️ PR Type
- [✔] Bug Fix
- 
📸 Screenshots
![image1](https://github.com/user-attachments/assets/b1646b6b-0cd4-4be3-9449-7764ba253903)
![image2](https://github.com/user-attachments/assets/8cc14d19-2561-4035-a2f7-6c90ee529c6e)
![image3](https://github.com/user-attachments/assets/6853b685-e6c9-4e4d-bccc-c69e9027e7ce)

💬 Notes to Reviewers
Please review the changes in the Dockerfile, especially the section where sample_configs is copied.
Let me know if any further modifications or additional tests are required.

When reproducing this issue, I found that without this change, the optimization would fail.
Please verify whether this fix is indeed essential for all use cases.
